### PR TITLE
[chart] add deploymentStrategy switch to chart values

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: helm-charts-oci-proxy
 description: Transparently proxy and transform Chart Repository styled Helm Charts as OCI artifacts. Now you can address any public Chart Repository styled Helm Chart as an OCI image.
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "a3a35bc"
 home: https://github.com/container-registry/helm-charts-oci-proxy
 icon: https://avatars.githubusercontent.com/u/46576199?s=200&v=4

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "ocip.selectorLabels" . | nindent 6 }}
+  {{- with .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+deploymentStrategy:
+  type: RollingUpdate
+
 image:
   repository: 8gears.container-registry.com/library/helm-charts-oci-proxy
   pullPolicy: Always


### PR DESCRIPTION
This PR adds an option to set the `.spec.strategy.type` in the deployment manifest to a different value.
https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

Which is necessary when persistent is enabled and the storage-provider only support "ReadWriteOnce"

