### PR TITLE
Added removal of "v" on handler

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -113,6 +113,9 @@ func (m *Manifests) Handle(resp http.ResponseWriter, req *http.Request) error {
 
 	elem = elem[1:]
 	target := elem[len(elem)-1]
+	if target != "" && strings.HasPrefix(target, "v") {
+		target = target[1:]
+	}
 
 	var repoParts []string
 	for i := len(elem) - 3; i > 0; i-- {


### PR DESCRIPTION
To align with the format of the manifests map (removes the v) and to address #17.

The prepareChart removes the "v" if it is on the chart version resulting in the manifest target keys to be without the "v".
Removing the v from the target variable seems to be fine, you seem to be able to use with the helm client either interchangeable after this change/with the repo itself by default. i.e.:

```
helm pull jetstack/cert-manager --version 1.15.3 == helm pull jetstack/cert-manager --version v1.15.3
``` 

I am not entirely sure if this will have any other impact, but so far this appears to address the issue mentioned previously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of version identifiers by refining the processing of the `target` variable.
	- Ensured compatibility with version strings that start with "v".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->