### PR TITLE
Added handler for OCI Artifacts not supporting the plus sign (+)

### DIFF
--- a/internal/manifest/charts.go
+++ b/internal/manifest/charts.go
@@ -44,13 +44,16 @@ func (m *Manifests) prepareChart(ctx context.Context, repo string, reference str
 		reference = fmt.Sprintf("v%s", reference)
 	}
 
-	if strings.Contains(reference, "_") {
-		reference = strings.ReplaceAll(reference, "_", "+")
-	}
-
 	m.log.Printf("searching index for %s with reference %s\n", chart, reference)
 	chartVer, err := index.Get(chart, reference)
 	if err != nil {
+		if strings.Contains(reference, "_") {
+			reference = strings.ReplaceAll(reference, "_", "+")
+		}
+		chartVer, err = index.Get(chart, reference)
+	}
+	if err != nil {
+
 		return &errors.RegError{
 			Status:  http.StatusNotFound,
 			Code:    "NOT FOUND",

--- a/internal/manifest/charts.go
+++ b/internal/manifest/charts.go
@@ -44,6 +44,10 @@ func (m *Manifests) prepareChart(ctx context.Context, repo string, reference str
 		reference = fmt.Sprintf("v%s", reference)
 	}
 
+	if strings.Contains(reference, "_") {
+		reference = strings.ReplaceAll(reference, "_", "+")
+	}
+
 	m.log.Printf("searching index for %s with reference %s\n", chart, reference)
 	chartVer, err := index.Get(chart, reference)
 	if err != nil {

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -116,9 +116,6 @@ func (m *Manifests) Handle(resp http.ResponseWriter, req *http.Request) error {
 	if target != "" && strings.HasPrefix(target, "v") {
 		target = target[1:]
 	}
-	if target != "" && strings.Contains(target, "_") {
-		target = strings.ReplaceAll(target, "_", "+")
-	}
 
 	var repoParts []string
 	for i := len(elem) - 3; i > 0; i-- {
@@ -201,11 +198,18 @@ func (m *Manifests) Handle(resp http.ResponseWriter, req *http.Request) error {
 			}
 			ma, ok = m.manifests[repo][target]
 			if !ok {
+				// check if chart was just remapped to an _ before failing
+				if target != "" && strings.Contains(target, "_") {
+					target = strings.ReplaceAll(target, "_", "+")
+				}
+				ma, ok = m.manifests[repo][target]
 				// we failed
-				return &errors.RegError{
-					Status:  http.StatusNotFound,
-					Code:    "NOT FOUND",
-					Message: "Chart prepare error",
+				if !ok {
+					return &errors.RegError{
+						Status:  http.StatusNotFound,
+						Code:    "NOT FOUND",
+						Message: "Chart prepare error",
+					}
 				}
 			}
 		}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -116,6 +116,9 @@ func (m *Manifests) Handle(resp http.ResponseWriter, req *http.Request) error {
 	if target != "" && strings.HasPrefix(target, "v") {
 		target = target[1:]
 	}
+	if target != "" && strings.Contains(target, "_") {
+		target = strings.ReplaceAll(target, "_", "+")
+	}
 
 	var repoParts []string
 	for i := len(elem) - 3; i > 0; i-- {


### PR DESCRIPTION
This is to fix #19, helm will automatically switch between the + to an _ because OCI Artifacts don't support the +.

To get around this I have added the logic, if the passed in version contains an _, to for do a lookup for + by replacing all the underscores then if that fails bomb out entirely.

This could be a problem if a tag contains both the + and _, but it will be impossible to tell since helm automatically changes the chart to a _ in all places so this might require more changes at the upstream helm handling.