### PR TITLE
Add custom and pod labels to Helm chart

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -40,6 +40,18 @@ helm.sh/chart: {{ include "ocip.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod labels
+*/}}
+{{- define "ocip.podLabels" -}}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 4 }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       {{- end }}
       labels:
         {{- include "ocip.selectorLabels" . | nindent 8 }}
+        {{- include "ocip.podLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,4 +1,6 @@
 replicaCount: 1
+# Will be added to all resources
+customLabels: {}
 
 deploymentStrategy:
   type: RollingUpdate
@@ -22,7 +24,7 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-  customLabels: {}
+  
 
 podAnnotations: {}
 podLabels: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -22,9 +22,10 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-
+  customLabels: {}
 
 podAnnotations: {}
+podLabels: {}
 
 podSecurityContext: {}
   # fsGroup: 2000
@@ -95,3 +96,5 @@ app:
     DEBUG: false
     USE_TLS: false
     CACHE_TTL: 3600
+
+customLabels: {}


### PR DESCRIPTION
Add customLabels and podLabels to values.yaml and update _helpers.tpl to handle them.

-  Add customLabels and podLabels fields to chart/values.yaml.
-  Modify ocip.labels function in chart/templates/_helpers.tpl to include customLabels.
-  Add a new function ocip.podLabels in chart/templates/_helpers.tpl to handle podLabels.
-  Update metadata labels in chart/templates/deployment.yaml to use the new ocip.podLabels function.

I need this as some kyverno policies depend on podlabels, which I am not able to set on this helm chart.