### PR TITLE
feat: Support custom CA certificates via extraVolumeMounts in Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ helm-charts-oci-proxy
 # vendor/
 go.work
 .idea
+.env
+.secrets

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             {{- else }}
           emptyDir: { }
             {{- end }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -56,12 +59,12 @@ spec:
             httpGet:
               path: /api/version
               port: http
-              scheme: {{- if .Values.app.useTLS }} HTTPS {{ else }} HTTP {{- end }}
+              scheme: {{- if .Values.app.env_vars.USE_TLS }} HTTPS {{ else }} HTTP {{- end }}
           readinessProbe:
             httpGet:
               path: /api/version
               port: http
-              scheme: {{- if .Values.app.useTLS }} HTTPS {{ else }} HTTP {{- end }}
+              scheme: {{- if .Values.app.env_vars.USE_TLS }} HTTPS {{ else }} HTTP {{- end }}
           env:
             {{- range $key, $value := .Values.app.env_vars }}
             - name: {{ $key }}
@@ -69,6 +72,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/data
+            {{- with .Values.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -59,12 +59,12 @@ spec:
             httpGet:
               path: /api/version
               port: http
-              scheme: {{- if .Values.app.env_vars.USE_TLS }} HTTPS {{ else }} HTTP {{- end }}
+              scheme: {{- if eq (lower (toString .Values.app.env_vars.USE_TLS)) "true" }} HTTPS {{ else }} HTTP {{- end }}
           readinessProbe:
             httpGet:
               path: /api/version
               port: http
-              scheme: {{- if .Values.app.env_vars.USE_TLS }} HTTPS {{ else }} HTTP {{- end }}
+              scheme: {{- if eq (lower (toString .Values.app.env_vars.USE_TLS)) "true" }} HTTPS {{ else }} HTTP {{- end }}
           env:
             {{- range $key, $value := .Values.app.env_vars }}
             - name: {{ $key }}

--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -9,10 +9,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "ocip.fullname" . }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "ocip.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/chart/tests/deployment_test.yaml
+++ b/chart/tests/deployment_test.yaml
@@ -1,0 +1,197 @@
+suite: deployment
+templates:
+  - templates/deployment.yaml
+
+tests:
+  #
+  # Probe scheme — USE_TLS truthiness
+  #
+  - it: should use HTTP scheme when USE_TLS is false (bool)
+    set:
+      app.env_vars.USE_TLS: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTP
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTP
+
+  - it: should use HTTPS scheme when USE_TLS is true (bool)
+    set:
+      app.env_vars.USE_TLS: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+
+  - it: should use HTTP scheme when USE_TLS is string "false"
+    set:
+      app.env_vars.USE_TLS: "false"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTP
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTP
+
+  - it: should use HTTPS scheme when USE_TLS is string "true"
+    set:
+      app.env_vars.USE_TLS: "true"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+
+  - it: should use HTTPS scheme when USE_TLS is string "True" (mixed case)
+    set:
+      app.env_vars.USE_TLS: "True"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS
+
+  #
+  # extraVolumes / extraVolumeMounts
+  #
+  - it: should not render extraVolumes when empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-ca
+          any: true
+
+  - it: should render extraVolumes
+    set:
+      extraVolumes:
+        - name: custom-ca
+          configMap:
+            name: ca-bundle
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: custom-ca
+            configMap:
+              name: ca-bundle
+
+  - it: should not render extraVolumeMounts when empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-ca
+          any: true
+
+  - it: should render extraVolumeMounts
+    set:
+      extraVolumeMounts:
+        - name: custom-ca
+          mountPath: /etc/ssl/custom
+          readOnly: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: custom-ca
+            mountPath: /etc/ssl/custom
+            readOnly: true
+
+  #
+  # Environment variables
+  #
+  - it: should render all default env vars with correct names
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MANIFEST_CACHE_TTL
+            value: "60"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INDEX_CACHE_TTL
+            value: "14400"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: INDEX_ERROR_CACHE_TTL
+            value: "30"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REWRITE_DEPENDENCIES
+            value: "false"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CACHE_TTL
+          any: true
+
+  #
+  # Image tag fallback
+  #
+  - it: should use appVersion when image.tag is empty
+    chart:
+      appVersion: "1.0.0"
+    set:
+      image.tag: ""
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ":1\\.0\\.0$"
+
+  - it: should use explicit tag when set
+    set:
+      image.tag: "v2.0.0"
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ":v2\\.0\\.0$"
+
+  #
+  # Persistence
+  #
+  - it: should use emptyDir when persistence is disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+
+  - it: should use PVC when persistence is enabled
+    set:
+      persistence.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-helm-charts-oci-proxy
+
+  - it: should use existingClaim when set
+    set:
+      persistence.enabled: true
+      persistence.existingClaim: my-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: my-existing-pvc

--- a/chart/tests/pvc_test.yaml
+++ b/chart/tests/pvc_test.yaml
@@ -1,0 +1,65 @@
+suite: pvc
+templates:
+  - templates/pvc.yaml
+
+tests:
+  - it: should not render PVC when persistence is disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render PVC when persistence is enabled
+    set:
+      persistence.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+
+  - it: should use standard labels
+    set:
+      persistence.enabled: true
+    asserts:
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/name"]
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/instance"]
+      - isNotEmpty:
+          path: metadata.labels["helm.sh/chart"]
+      - isNotEmpty:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+      - notExists:
+          path: metadata.labels.heritage
+      - notExists:
+          path: metadata.labels.chart
+      - notExists:
+          path: metadata.labels.release
+
+  - it: should not render PVC when existingClaim is set
+    set:
+      persistence.enabled: true
+      persistence.existingClaim: my-existing-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should respect storage size
+    set:
+      persistence.enabled: true
+      persistence.size: 10Gi
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: "10Gi"
+
+  - it: should respect access mode
+    set:
+      persistence.enabled: true
+      persistence.accessMode: ReadWriteMany
+    asserts:
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteMany

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: 8gears.container-registry.com/library/helm-charts-oci-proxy
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: ""
 
 imagePullSecrets: []
 
@@ -72,6 +72,7 @@ resources:
 # persistence
 persistence:
   enabled: false
+  existingClaim: ""
   size: 5Gi
   # storageClass: "-"
   accessMode: ReadWriteOnce
@@ -95,4 +96,11 @@ app:
   env_vars:
     DEBUG: false
     USE_TLS: false
-    CACHE_TTL: 3600
+    MANIFEST_CACHE_TTL: 60
+    INDEX_CACHE_TTL: 14400
+    INDEX_ERROR_CACHE_TTL: 30
+    REWRITE_DEPENDENCIES: false
+    PROXY_HOST: ""
+
+extraVolumes: []
+extraVolumeMounts: []


### PR DESCRIPTION
resolve #43 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for extraVolumes and extraVolumeMounts in the Helm chart to mount custom CA certs and other files. Fixes probe scheme handling and image tag fallback, and adds chart tests. Addresses #43.

- **New Features**
  - Support extraVolumes and extraVolumeMounts via values (useful for custom CA certs).
  - Add persistence.existingClaim to bind to a pre-created PVC.
  - Expose new app env vars for cache tuning and proxy settings.

- **Bug Fixes**
  - Probes now read USE_TLS from env with a safe boolean check (handles "true"/"false"); added helm-unittest coverage for probes, volumes, env vars, image tag fallback, and persistence.
  - PVC labels use the standard ocip.labels helper for consistency.
  - Default image.tag set to empty to fall back to chart appVersion.

<sup>Written for commit 1ca1cc4c10f107b1bfdd2b14b10ce15a7b5aeb8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added caching options for manifest, index, and error caches
  * Added proxy host configuration support
  * Added optional custom volumes and volume mounts, plus existing PVC support
  * Image tag can be left empty to allow fallback to chart/app version

* **Tests**
  * Added comprehensive chart tests covering probes, TLS handling, volumes, env vars, image tag resolution, and PVC scenarios

* **Chores**
  * Updated .gitignore to exclude environment and secrets files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->